### PR TITLE
4 add readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Shadcn Native
 
-<img src="https://img.shields.io/badge/Expo-1B1F23" />
-<img src="https://img.shields.io/badge/React_Native-20232A" />
-<img src="https://img.shields.io/badge/iOS-000000" />
-<img src="https://img.shields.io/badge/Android-3DDC84" />
-<img src="https://img.shields.io/badge/MIT-green" />
+<div style="display: flex; flex-direction: row;">
+  <img src="https://img.shields.io/badge/Expo-1B1F23" />
+  <img src="https://img.shields.io/badge/React_Native-20232A" />
+  <img src="https://img.shields.io/badge/iOS-000000" />
+  <img src="https://img.shields.io/badge/Android-3DDC84" />
+  <img src="https://img.shields.io/badge/MIT-green" />
+</div>
+
+<br />
 
 Shadcn native is a port of [shadcn/ui](https://github.com/shadcn-ui/ui) for React Native and React Native Web.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rebranded README to “Shadcn Native” with updated project description.
  * Added badges for Expo, React Native, iOS, Android, and MIT.
  * Linked to new documentation site and shadcn-native docs.
  * Introduced Contributing guidelines and clarified licensing (MIT).
  * Added attribution line.
  * Removed outdated Next.js-specific setup and resources for a cleaner, platform-appropriate overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->