### PR TITLE
chore: add more links to gh issue config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,12 @@ contact_links:
   - name: 📚 Documentation
     url: https://shadcn-native.moveinready.casa/
     about: Check the documentation for usage guides and examples
+  - name: 🛡️ Security Policy
+    url: https://github.com/moveinready-casa/shadcn-native/security/policy
+    about: Report vulnerabilities privately (see supported info and process)
+  - name: 📜 Contributing
+    url: https://github.com/moveinready-casa/shadcn-native/blob/main/CONTRIBUTING.md
+    about: See how to contribute to this project
   - name: 🎨 Storybook
     url: https://main--68af7af75f72e5521a7e0f93.chromatic.com/?path=/docs/welcome--docs
     about: View component examples and demos in Storybook


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contact links for Security Policy and Contributing in the issue chooser to guide users to the right resources when opening issues.
  * Improves discoverability of how to report security concerns and how to contribute.
  * No functional changes to the product; impacts GitHub issue filing experience only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->