### PR TITLE
docs: update otp lib link

### DIFF
--- a/app/docs/components/input-otp/page.mdx
+++ b/app/docs/components/input-otp/page.mdx
@@ -44,4 +44,4 @@ import {
 </InputOTP>;
 ```
 
-The input OTP is a wrapper around the [TextInputOTP](https://github.com/moveinready-casa/react-native-input-code-otp) component.
+The input OTP is a wrapper around the [TextInputOTP](https://github.com/johelder/react-native-input-code-otp) component.


### PR DESCRIPTION
- Docs
  - Updated the OTP input documentation to reference the correct library repository, ensuring users are directed to the maintained source.